### PR TITLE
added example deathrattle unit type and deathrattle mechanics

### DIFF
--- a/Assets/Classes/Character.cs
+++ b/Assets/Classes/Character.cs
@@ -16,6 +16,9 @@ public class Character
     Tile tile;
 
     private Arena arena;
+    private bool died;
+
+    private System.Action<Tile, bool> deathrattle;
 
     public Character(string name_, int power_, bool playerUnit_, GameObject gameObject_, Tile tile_, GameObject canvasInfo_)
     {
@@ -30,6 +33,10 @@ public class Character
         powerInfo.text="Power:" + power.ToString();
 
         arena = (Arena)GameObject.FindObjectOfType(typeof(Arena));
+        died = false;
+
+        // initialize functions
+        deathrattle = delegate (Tile tile, bool side) { };
     }
 
     public void Move(Arena.Direction direction)
@@ -81,7 +88,7 @@ public class Character
     public bool TakeDamage(int dmg)
     {
         this.power -= dmg;
-        if (power <= 0)
+        if (power <= 0 && !died)
         {
             this.Die();
             return true;
@@ -105,6 +112,10 @@ public class Character
     {
         // possible death rattle activation
 
+        died = true;
+
+        deathrattle(tile, playerUnit);
+
         tile.UnitDied();
         UnityEngine.GameObject.Destroy(gameObject);
         UnityEngine.GameObject.Destroy(canvasInfo);
@@ -122,5 +133,10 @@ public class Character
     public void HideAttackInfo()
     {
         canvasInfo.SetActive(false);
+    }
+
+    public void AddDeathrattle(Action<Tile, bool> deathrattle_)
+    {
+        this.deathrattle = deathrattle_;
     }
 }

--- a/Assets/Classes/Tile.cs
+++ b/Assets/Classes/Tile.cs
@@ -25,6 +25,7 @@ public class Tile
         this.mesh = mesh_;
         this.id = _id;
         isClicked = false;
+        character = null;
 
         arena = (Arena)GameObject.FindObjectOfType(typeof(Arena));
         if (!arena)
@@ -67,6 +68,11 @@ public class Tile
     {
         isClicked = false;
         mesh.material.color = mainColor;
+    }
+
+    public void Damage(Arena.PlayerUnitTarget put, Arena.UnitTargetGroup utg, bool side, int damage)
+    {
+        arena.Damage(put, utg, this, side, damage);
     }
 }
 

--- a/Assets/Units/UnitSpawn.cs
+++ b/Assets/Units/UnitSpawn.cs
@@ -19,6 +19,7 @@ public class UnitSpawn : MonoBehaviour
     public enum UnitType
     {
         DEFAULT = 0,
+        DEATHRATTLE,
         COUNT,
     }
     //spawning unit on map
@@ -44,33 +45,65 @@ public class UnitSpawn : MonoBehaviour
     }
     private Character CreateUnit(Tile tile, UnitType unitType, bool playerUnit, int power, GameObject info)
     {
-        Vector3 position = tile.gameObject.gameObject.transform.position;
+        Vector3 position = tile.unitPosition;
+        Vector3 rotation = new Vector3(0, 0, 0);
+        if (playerUnit)
+        {
+            //rotate
+            rotation = new Vector3(0, 180f, 0);
+        }
+        GameObject characterObject = null;
+        Character character = null;
         switch (unitType)
         {
             case UnitType.DEFAULT:
-                position.y += 0.1f;
-                Vector3 rotation= new Vector3(0, 0, 0);
-                if (playerUnit) 
-                {
-                    //rotate
-                    rotation =  new Vector3(0,180f,0);
-                }
                 transform.localScale = new Vector3(0.25f, 0.5f, 0.25f);
-                GameObject characterObject = Instantiate(defaultUnitPrefab, position, Quaternion.Euler(rotation), transform);
-                MeshRenderer cubeMesh = characterObject.transform.Find("Cube").GetComponent<MeshRenderer>();
-                MeshRenderer cyllinderMesh = characterObject.transform.Find("Cylinder").GetComponent<MeshRenderer>();
-                if (playerUnit)
+                characterObject = Instantiate(defaultUnitPrefab, position, Quaternion.Euler(rotation), transform);
                 {
+                    MeshRenderer cubeMesh = characterObject.transform.Find("Cube").GetComponent<MeshRenderer>();
+                    MeshRenderer cyllinderMesh = characterObject.transform.Find("Cylinder").GetComponent<MeshRenderer>();
+                    if (playerUnit)
+                    {
 
-                    cubeMesh.material.color = playerColor;
-                    cyllinderMesh.material.color = playerColor;
+                        cubeMesh.material.color = playerColor;
+                        cyllinderMesh.material.color = playerColor;
+                    }
+                    else
+                    {
+                        cubeMesh.material.color = opponentColor;
+                        cyllinderMesh.material.color = opponentColor;
+                    }
                 }
-                else
+                character = new Character("Tank", power, playerUnit, characterObject, tile, info);
+                return character;
+
+            case UnitType.DEATHRATTLE:
+                transform.localScale = new Vector3(0.25f, 0.5f, 0.25f);
+                characterObject = Instantiate(defaultUnitPrefab, position, Quaternion.Euler(rotation), transform);
                 {
-                    cubeMesh.material.color = opponentColor;
-                    cyllinderMesh.material.color = opponentColor;
+                    MeshRenderer cubeMesh = characterObject.transform.Find("Cube").GetComponent<MeshRenderer>();
+                    MeshRenderer cyllinderMesh = characterObject.transform.Find("Cylinder").GetComponent<MeshRenderer>();
+                    if (playerUnit)
+                    {
+
+                        cubeMesh.material.color = playerColor;
+                        cyllinderMesh.material.color = playerColor;
+                    }
+                    else
+                    {
+                        cubeMesh.material.color = opponentColor;
+                        cyllinderMesh.material.color = opponentColor;
+                    }
                 }
-                Character character = new Character("Tank", power, playerUnit, characterObject, tile, info);
+                character = new Character("Tank", power, playerUnit, characterObject, tile, info);
+
+                // set deathrattle
+                System.Action<Tile, bool> newDeathrattle = delegate (Tile origintile, bool side)
+                {
+                    origintile.Damage(Arena.PlayerUnitTarget.ENEMY, Arena.UnitTargetGroup.ALL, side, 3);
+                };
+                character.AddDeathrattle(newDeathrattle);
+
                 return character;
 
             default:


### PR DESCRIPTION
To not cause merge conflicts no card spawns deathrattle - just change in "all cards" object one card to summon "deathrattle" unit type instead of default unit